### PR TITLE
Avoid crash when no app can open a link

### DIFF
--- a/app/src/main/java/io/github/ronynn/karui/MainActivity.java
+++ b/app/src/main/java/io/github/ronynn/karui/MainActivity.java
@@ -3,6 +3,7 @@ package io.github.ronynn.karui;
 import android.animation.ObjectAnimator;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -15,6 +16,7 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 import org.json.JSONObject;
 
@@ -66,7 +68,11 @@ public class MainActivity extends Activity {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                view.getContext().startActivity(intent);
+                try {
+                    view.getContext().startActivity(intent);
+                } catch (ActivityNotFoundException e) {
+                    Toast.makeText(view.getContext(), R.string.no_app_to_open_link, Toast.LENGTH_SHORT).show();
+                }
                 return true;
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <string name="app_name">Karui</string>
+    <string name="no_app_to_open_link">No app found to open this link</string>
 
 </resources>


### PR DESCRIPTION
`MainActivity.shouldOverrideUrlLoading` opens every link with `startActivity`. On a device with no app for the link this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short toast when nothing can open the link. Links still open in their app when one is available.

Closes #24
